### PR TITLE
feat: don't test on old versions of node

### DIFF
--- a/app/templates/travis.yml
+++ b/app/templates/travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
+  - stable
   - v6
-  - v5
   - v4
-  - '0.12'
-  - '0.10'
 sudo: false


### PR DESCRIPTION
- remove 0.12 and 0.10. They are missing a lot of interesting ES6 features
- remove v5. It is unsupported by the Node project
- put stable on top of v6. That way, when a new version goes out it will be automatically tested
